### PR TITLE
added environment variable set to define the sub

### DIFF
--- a/create_new_vm.yml
+++ b/create_new_vm.yml
@@ -27,9 +27,13 @@
   vars_files:
       - var_holder.yml
 
+  environment:
+    AZURE_SUBSCRIPTION_ID: "{{subscription_id}}"
+
   tasks:
     # Uncomment the below if you want to have the script set the default az client subscription, just in case. Comment out if not.
-    # You can also add client_id, secret, tenant_id, and subscriptin_id to each method or environment variables to use a service principal.
+    # You can also add client_id, secret, tenant_id, and subscription_id to each method or environment variables to use a service principal.
+    # setting the environment variable, this is probably not needed but will leave for now.
     - name: Azure CLI Set Active Subscription
       command: az account set --subscription "{{subscription_id}}"
     #

--- a/create_stub_plumbing.yml
+++ b/create_stub_plumbing.yml
@@ -10,10 +10,13 @@
   vars_files:
       - var_holder.yml
 
+  environment:
+    AZURE_SUBSCRIPTION_ID: "{{subscription_id}}"
 
   tasks:
     # Uncomment the below if you want to have the script set the default az client subscription, just in case. Comment out if not.
-    # You can also add client_id, secret, tenant_id, and subscriptin_id to each method or environment variables to use a service principal.
+    # You can also add client_id, secret, tenant_id, and subscription_id to each method or environment variables to use a service principal.
+    # setting the environment variable, this is probably not needed but will leave for now.
     - name: Azure CLI Set Active Subscription
       command: az account set --subscription "{{subscription_id}}"
     #

--- a/remove_existing_vm.yml
+++ b/remove_existing_vm.yml
@@ -18,10 +18,16 @@
   vars_files:
       - var_holder.yml
 
+  
+  environment:
+    AZURE_SUBSCRIPTION_ID: "{{subscription_id}}"
+
+
   tasks:
 
   # Uncomment the below if you want to have the script set the default az client subscription, just in case. Comment out if not.
-    # You can also add client_id, secret, tenant_id, and subscriptin_id to each method or environment variables to use a service principal.
+    # You can also add client_id, secret, tenant_id, and subscription_id to each method or environment variables to use a service principal.
+    # setting the environment variable, this is probably not needed but will leave for now.
     - name: Azure CLI Set Active Subscription
       command: az account set --subscription "{{subscription_id}}"
     #


### PR DESCRIPTION
Original testing apparently had some remnants that produced a false positive on setting the desired subscription in cases of multiple subs. Added an environment set task to define the environment variable used by the az toolset to consume azure appropriately.